### PR TITLE
Revert hubot-rss-reader

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -9,7 +9,6 @@
   "hubot-maps",
   "hubot-redis-brain",
   "hubot-rules",
-  "hubot-rss-reader",
   "hubot-shipit",
   "hubot-table-flip",
   "hubot-plusplus"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Devin Weaver <suki@tritarget.org>",
   "description": "A simple helpful robot for your meetup",
   "dependencies": {
-    "coffee-script": "^1.9.3",
     "hubot": "^2.13.2",
     "hubot-darts": "^1.0.1",
     "hubot-diagnostics": "0.0.1",
@@ -17,7 +16,6 @@
     "hubot-plusplus": "^1.1.5",
     "hubot-pugme": "^0.1.0",
     "hubot-redis-brain": "0.0.3",
-    "hubot-rss-reader": "^0.6.9",
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.16.1",
     "hubot-shipit": "^0.2.0",


### PR DESCRIPTION
It seems after using the hubot-rss-reader that it isn't as useful as I had wished. First adding an RSS feed causes Hubot to vomit all over the chat as it spews every RSS entry in the list. Then when it updates and attempts to display the next unread message you get this:

<img width="556" alt="screen shot 2015-08-19 at 08 14 53" src="https://cloud.githubusercontent.com/assets/70075/9356129/894412d8-464c-11e5-913b-b20f91adaf88.png">

Note: this is probably a culmination of the plugin code itself and an unreliable RSS feed. Either way the utility of this seems less than ideal. Better to remove it and find another way to manage useful feeds in Slack/Hubot.

> This reverts commit f1c3cb7e0b55514c89397a46370b6f66231805e6, reversing changes made to 03b953dcf5a551095ccb46e71cfd2dac8b562ef0.
