### PR TITLE
Update heroku-keepalive module to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "hubot-google-images": "^0.1.5",
     "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.1.1",
-    "hubot-heroku-keepalive": "0.0.4",
+    "hubot-heroku-keepalive": "^1.0.0",
     "hubot-maps": "0.0.2",
     "hubot-plusplus": "^1.1.5",
     "hubot-pugme": "^0.1.0",


### PR DESCRIPTION
The `hubot-heroku-keepalive` module was [recently updated](https://github.com/hubot-scripts/hubot-heroku-keepalive/issues/8) to comply with Heroku's dyno sleeping policy.
