### PR TITLE
Feature/suggest jobs post

### DIFF
--- a/scripts/jobs-suggestion.js
+++ b/scripts/jobs-suggestion.js
@@ -39,4 +39,8 @@ module.exports = function(robot) {
       });
     }
   });
+
+  robot.respond(/!job(s)?\b/, function(msg) {
+    msg.send(response());
+  });
 }

--- a/scripts/jobs-suggestion.js
+++ b/scripts/jobs-suggestion.js
@@ -1,0 +1,42 @@
+/**
+ * Description:
+ * Politely remind folks posting a url in #job-board to make a PR
+ *
+ * Dependencies:
+ *   None
+ *
+ * Configuration:
+ *   None
+ *
+ * Commands:
+ * post something that looks like a url
+ *
+ * Author:
+ *   treznick
+ */
+
+function getRandomIntegerBelow(max) {
+  return Math.floor(Math.random() * Math.floor(max));
+}
+
+function maybe(p, fn) {
+  let randomValue = getRandomIntegerBelow(100)
+  if (randomValue < p) {
+    fn();
+  }
+}
+
+function response() {
+  return 'Hi! please post jobs via a pull request to https://github.com/newhavenio/newhavenio';
+}
+
+module.exports = function(robot) {
+  robot.hear(/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi, function(msg) {
+    let max = parseInt(process.env.JOBS_SUGGESTION_MAX_PERCENTAGE, 10) || 100
+    if(msg.message.user.room === process.env.JOBS_BOARD_ROOM) {
+      maybe(max, function() {
+        msg.send(response());
+      });
+    }
+  });
+}

--- a/test/jobs-suggestion-test.coffee
+++ b/test/jobs-suggestion-test.coffee
@@ -1,0 +1,52 @@
+Helper = require 'hubot-test-helper'
+chai = require 'chai'
+
+expect = chai.expect
+
+helper = new Helper('../scripts/jobs-suggestion.js')
+
+response = "Hi! please post jobs via a pull request to https://github.com/newhavenio/newhavenio"
+
+describe 'jobs-suggestion', ->
+  context 'in #jobs', ->
+    beforeEach ->
+      process.env.JOBS_SUGGESTION_MAX_PERCENTAGE = "100"
+      process.env.JOBS_BOARD_ROOM = "jobs"
+      @room = helper.createRoom({name: 'jobs'})
+
+    afterEach ->
+      delete process.env.JOBS_SUGGESTION_MAX_PERCENTAGE
+      delete process.env.JOBS_BOARD_ROOM
+      @room.destroy()
+
+    context 'with a url', ->
+      it 'responds to a url', ->
+        @room.user.say('alice', 'check out my job post here: https://www.example.com').then =>
+          expect(@room.messages[0..1]).to.eql [
+            ['alice', 'check out my job post here: https://www.example.com'],
+            ['hubot', response]
+          ]
+
+    context 'without a url', ->
+      it 'does not respond', ->
+        @room.user.say('alice', 'check out my job post here: not a url').then =>
+          expect(@room.messages[0..1]).to.eql [
+            ['alice', 'check out my job post here: not a url'],
+          ]
+
+  context 'somewhere else', ->
+    beforeEach ->
+      process.env.JOBS_SUGGESTION_MAX_PERCENTAGE = "100"
+      @room = helper.createRoom({name: 'general'})
+
+    afterEach ->
+      delete process.env.JOBS_SUGGESTION_MAX_PERCENTAGE
+      delete process.env.JOBS_BOARD_ROOM
+      @room.destroy()
+
+    context 'with a url', ->
+      it 'does not respond', ->
+        @room.user.say('alice', 'check out my job post here: not a url').then =>
+          expect(@room.messages[0..1]).to.eql [
+            ['alice', 'check out my job post here: not a url'],
+          ]

--- a/test/jobs-suggestion-test.coffee
+++ b/test/jobs-suggestion-test.coffee
@@ -34,6 +34,22 @@ describe 'jobs-suggestion', ->
             ['alice', 'check out my job post here: not a url'],
           ]
 
+    context 'when called directly', ->
+      it 'responds', ->
+        @room.user.say('alice', '@hubot !job').then =>
+          expect(@room.messages[0..1]).to.eql [
+            ['alice', '@hubot !job'],
+            ['hubot', response]
+          ]
+
+    context 'when called directly with plural', ->
+      it 'responds', ->
+        @room.user.say('alice', '@hubot !jobs').then =>
+          expect(@room.messages[0..1]).to.eql [
+            ['alice', '@hubot !jobs'],
+            ['hubot', response]
+          ]
+
   context 'somewhere else', ->
     beforeEach ->
       process.env.JOBS_SUGGESTION_MAX_PERCENTAGE = "100"
@@ -49,4 +65,20 @@ describe 'jobs-suggestion', ->
         @room.user.say('alice', 'check out my job post here: not a url').then =>
           expect(@room.messages[0..1]).to.eql [
             ['alice', 'check out my job post here: not a url'],
+          ]
+
+    context 'when called directly', ->
+      it 'responds', ->
+        @room.user.say('alice', '@hubot !job').then =>
+          expect(@room.messages[0..1]).to.eql [
+            ['alice', '@hubot !job'],
+            ['hubot', response]
+          ]
+
+    context 'when called directly with plural', ->
+      it 'responds', ->
+        @room.user.say('alice', '@hubot !jobs').then =>
+          expect(@room.messages[0..1]).to.eql [
+            ['alice', '@hubot !jobs'],
+            ['hubot', response]
           ]


### PR DESCRIPTION
This PR adds two new hubot  features. iobot will post:
> Hi! please post jobs via a pull request to https://github.com/newhavenio/newhavenio'
 in response to anything resembling a url posted in `JOBS_BOARD_ROOM`. This can be ramped up with `JOBS_SUGGESTION_MAX_PERCENTAGE`
 
 Additionally, a user can directly invoke this via `@iobot !job` or `@iobot !jobs`